### PR TITLE
Revert "Updated fighter name assignations to the new format"

### DIFF
--- a/data/jobs/escort-109.txt
+++ b/data/jobs/escort-109.txt
@@ -13,8 +13,7 @@ mission "Ruin-the-Fun Escort 109"
 		personality escort disables
 		fleet
 			names "korath"
-			fighters
-				names "korath"
+			fighters "korath"
 			variant
 				"Ruin-The-Fun 109 (Auto)"
 				"Ruin-The-Fun Petrel" 7

--- a/data/jobs/fight-combat-drones.txt
+++ b/data/jobs/fight-combat-drones.txt
@@ -100,8 +100,7 @@ mission "Ruin-the-Fun Combat Drones"
 
 fleet "Ruin-the-Fun 1 Combat Drone"
 	names "republic capital"
-	fighters
-		names "republic fighter"
+	fighters "republic fighter"
 	cargo 0
 	government "Ruin-The-Fun (Hostile)"
 	personality heroic disables

--- a/data/jobs/fight-rtf-109.txt
+++ b/data/jobs/fight-rtf-109.txt
@@ -46,8 +46,7 @@ mission "Ruin-the-Fun Combat RTF 109"
 		personality heroic disables
 		fleet
 			names "korath"
-			fighters
-				names "korath"
+			fighters "korath"
 			variant
 				"Ruin-The-Fun 109 (Auto)"
 				"Ruin-The-Fun Petrel" 7
@@ -61,8 +60,7 @@ mission "Ruin-the-Fun Combat RTF 109"
 		personality heroic disables
 		fleet
 			names "korath"
-			fighters
-				names "korath"
+			fighters "korath"
 			variant
 				"Ruin-The-Fun 109 (Auto)"
 				"Ruin-The-Fun Petrel" 7
@@ -76,8 +74,7 @@ mission "Ruin-the-Fun Combat RTF 109"
 		personality heroic disables
 		fleet
 			names "korath"
-			fighters
-				names "korath"
+			fighters "korath"
 			variant
 				"Ruin-The-Fun 109 (Auto)"
 				"Ruin-The-Fun Petrel" 7
@@ -91,8 +88,7 @@ mission "Ruin-the-Fun Combat RTF 109"
 		personality heroic disables
 		fleet
 			names "korath"
-			fighters
-				names "korath"
+			fighters "korath"
 			variant
 				"Ruin-The-Fun 109 (Auto)"
 				"Ruin-The-Fun Petrel" 7


### PR DESCRIPTION
Reverts Pshy0/es-ruin-the-fun#2

Because using `fighters <names>` is no longer deprecated.
This PR aims at eliminating the warnings on older versions.