### PR TITLE
Prevent minor landing missions from offering on RTF planets.

### DIFF
--- a/data/missions/no-landing-offers-on-rtf.txt
+++ b/data/missions/no-landing-offers-on-rtf.txt
@@ -1,6 +1,6 @@
 ## Prevents minor landing missions from offering on RTF planets.
 
-mission "A 000000 Ruin-the-Fun No Minor Landing Missions"
+mission "zzzzzz Ruin-the-Fun No Minor Landing Missions"
 	minor
 	invisible
 	repeat

--- a/data/missions/no-landing-offers-on-rtf.txt
+++ b/data/missions/no-landing-offers-on-rtf.txt
@@ -1,0 +1,10 @@
+## Prevents minor landing missions from offering on RTF planets.
+
+mission "A 000000 Ruin-the-Fun No Minor Landing Missions"
+	minor
+	invisible
+	repeat
+	source
+		government "Ruin-The-Fun"
+	on enter
+		fail


### PR DESCRIPTION
This file adds an invisible minor landing mission that offers every time you land on RTF planets.
The goal is to prevent other minor missions from offering.
I needed this to prevent a couple of plugins from spamming me with missions when I didn't yet left the RTF system.

I had this file non-tracked for a while. I remember I though it had side effects, or perhaps it might not be wanted if you want a minor mission to trigger when landing on RTF.